### PR TITLE
Fix node layouting so it's properly triggered after each debug stop event

### DIFF
--- a/packages/webview-ui/src/components/nodes/base.ts
+++ b/packages/webview-ui/src/components/nodes/base.ts
@@ -1,4 +1,5 @@
 export type BaseNodeData = {
   name?: string;
   isLayouted?: boolean;
+  measuredSize: { w: number; h: number } | null;
 };

--- a/packages/webview-ui/src/components/nodes/common/ArrayNode.tsx
+++ b/packages/webview-ui/src/components/nodes/common/ArrayNode.tsx
@@ -4,14 +4,19 @@ import { VariablesListItem } from "./VariablesList";
 
 import "./CommonNode.css";
 import "./ArrayNode.css";
+import { useRef } from "react";
+import { useMeasureNode } from "../hooks";
 
 export type ArrayData = BaseNodeData & {
   items: VariablesListItem[];
 };
 
 export default function ArrayNode(props: NodeProps<ArrayData>) {
+  const divRef = useRef<HTMLDivElement | null>(null);
+  useMeasureNode(divRef, props.data.measuredSize);
+
   return (
-    <div className="common-node variables-node">
+    <div ref={divRef} className="common-node variables-node">
       <div className="common-node-header">{props.data.name}</div>
       <Handle className="variables-node-handle" position={Position.Left} type="target" />
       <div className="array-list">

--- a/packages/webview-ui/src/components/nodes/common/StackFrameNode.tsx
+++ b/packages/webview-ui/src/components/nodes/common/StackFrameNode.tsx
@@ -3,6 +3,8 @@ import "./StackFrameNode.css";
 import { NodeProps } from "reactflow";
 import { VariablesList, VariablesListItem } from "./VariablesList";
 import { BaseNodeData } from "../base";
+import { useRef } from "react";
+import { useMeasureNode } from "../hooks";
 
 export type StackFrameData = BaseNodeData & {
   scopes: ScopeData[];
@@ -16,8 +18,11 @@ export type ScopeData = {
 };
 
 export default function StackFrameNode(props: NodeProps<StackFrameData>) {
+  const divRef = useRef<HTMLDivElement | null>(null);
+  useMeasureNode(divRef, props.data.measuredSize);
+
   return (
-    <div className="common-node stack-frame-node">
+    <div ref={divRef} className="common-node stack-frame-node">
       <div className="common-node-header">{props.data.name}</div>
       {props.data.scopes.map((scopeData) => (
         <div className="common-node stack-frame-scope" key={scopeData.name}>

--- a/packages/webview-ui/src/components/nodes/common/StackTraceNode.tsx
+++ b/packages/webview-ui/src/components/nodes/common/StackTraceNode.tsx
@@ -2,12 +2,17 @@ import "./CommonNode.css";
 import "./StackTraceNode.css";
 import { NodeProps } from "reactflow";
 import { BaseNodeData } from "../base";
+import { useRef } from "react";
+import { useMeasureNode } from "../hooks";
 
 export type StackTraceData = BaseNodeData;
 
-export default function StackTraceNode(_props: NodeProps<StackTraceData>) {
+export default function StackTraceNode(props: NodeProps<StackTraceData>) {
+  const divRef = useRef<HTMLDivElement | null>(null);
+  useMeasureNode(divRef, props.data.measuredSize);
+
   return (
-    <div className="common-node stack-trace-node">
+    <div ref={divRef} className="common-node stack-trace-node">
       <div className="stack-trace-header">Stack Trace</div>
     </div>
   );

--- a/packages/webview-ui/src/components/nodes/common/VariablesNode.tsx
+++ b/packages/webview-ui/src/components/nodes/common/VariablesNode.tsx
@@ -1,17 +1,21 @@
+import "./CommonNode.css";
+import "./VariablesNode.css";
 import { NodeProps, Handle, Position } from "reactflow";
 import { VariablesList, VariablesListItem } from "./VariablesList";
 import { BaseNodeData } from "../base";
-
-import "./CommonNode.css";
-import "./VariablesNode.css";
+import { useRef } from "react";
+import { useMeasureNode } from "../hooks";
 
 export type VariablesData = BaseNodeData & {
   items: VariablesListItem[];
 };
 
 export default function VariablesNode(props: NodeProps<VariablesData>) {
+  const divRef = useRef<HTMLDivElement | null>(null);
+  useMeasureNode(divRef, props.data.measuredSize);
+
   return (
-    <div className="common-node variables-node">
+    <div ref={divRef} className="common-node variables-node">
       <div className="common-node-header">{props.data.name}</div>
       <Handle className="variables-node-handle" position={Position.Left} type="target" />
       <VariablesList nodeId={props.id} items={props.data.items} />

--- a/packages/webview-ui/src/components/nodes/hooks.ts
+++ b/packages/webview-ui/src/components/nodes/hooks.ts
@@ -1,0 +1,45 @@
+import { RefObject, useContext, useLayoutEffect } from "react";
+import { useAppDispatch } from "../../hooks";
+import { nodeMeasured } from "../../features/sessions/debugSessions/default/defaultActions";
+import SessionContext from "../../features/sessions/SessionContext";
+import { useNodeId } from "reactflow";
+import { BaseNodeData } from "./base";
+
+/**
+ * Hook that dispatches the `nodeMeasured` action after the node is rendered
+ * and its dimensions are measured.
+ *
+ * @param ref A reference to the root `div` element of the node which will be measured.
+ * @param measuredSize The current `measuredSize` of the node data.
+ */
+export function useMeasureNode(
+  ref: RefObject<HTMLDivElement | null>,
+  measuredSize: BaseNodeData["measuredSize"],
+) {
+  const dispatch = useAppDispatch();
+  const nodeId = useNodeId();
+  const session = useContext(SessionContext);
+
+  const offsetWidth = ref.current?.offsetWidth ?? 0;
+  const offsetHeight = ref.current?.offsetHeight ?? 0;
+
+  useLayoutEffect(() => {
+    if (ref.current === null) {
+      console.warn("useMeasureNode: ref.current is null. Did you forget to use the ref?");
+      return;
+    }
+
+    if (!nodeId || !session) {
+      return;
+    }
+
+    if (!measuredSize) {
+      // Size hasn't been measured for this render yet, so report the measurement.
+      const size = {
+        h: offsetHeight,
+        w: offsetWidth,
+      };
+      dispatch(nodeMeasured(session.id, { id: nodeId, size }));
+    }
+  }, [measuredSize, offsetWidth, offsetHeight]);
+}

--- a/packages/webview-ui/src/components/nodes/hooks.ts
+++ b/packages/webview-ui/src/components/nodes/hooks.ts
@@ -20,9 +20,6 @@ export function useMeasureNode(
   const nodeId = useNodeId();
   const session = useContext(SessionContext);
 
-  const offsetWidth = ref.current?.offsetWidth ?? 0;
-  const offsetHeight = ref.current?.offsetHeight ?? 0;
-
   useLayoutEffect(() => {
     if (ref.current === null) {
       console.warn("useMeasureNode: ref.current is null. Did you forget to use the ref?");
@@ -36,10 +33,10 @@ export function useMeasureNode(
     if (!measuredSize) {
       // Size hasn't been measured for this render yet, so report the measurement.
       const size = {
-        h: offsetHeight,
-        w: offsetWidth,
+        h: ref.current.offsetHeight,
+        w: ref.current.offsetWidth,
       };
       dispatch(nodeMeasured(session.id, { id: nodeId, size }));
     }
-  }, [measuredSize, offsetWidth, offsetHeight]);
+  }, [measuredSize, ref.current]);
 }

--- a/packages/webview-ui/src/features/sessions/SessionContext.ts
+++ b/packages/webview-ui/src/features/sessions/SessionContext.ts
@@ -1,0 +1,5 @@
+import { createContext } from "react";
+import { SessionEntity } from "./entities";
+
+const SessionContext = createContext<SessionEntity | undefined>(undefined);
+export default SessionContext;

--- a/packages/webview-ui/src/features/sessions/debugSessions/default/DefaultFlowComponent.tsx
+++ b/packages/webview-ui/src/features/sessions/debugSessions/default/DefaultFlowComponent.tsx
@@ -1,9 +1,8 @@
 import "./DefaultFlowComponent.css";
-import { useLayoutEffect } from "react";
-import { Background, Controls, ReactFlow, useNodesInitialized } from "reactflow";
+import { Background, Controls, ReactFlow } from "reactflow";
 import { useAppDispatch, useAppSelector } from "../../../../hooks";
 import { edgesAdapter, nodesAdapter } from "../../entities";
-import { layoutNodes, nodesChanged } from "./defaultActions";
+import { nodesChanged } from "./defaultActions";
 import { nodeTypes } from "../../../../components/nodes";
 import { edgeTypes } from "../../../../components/edges";
 import LoadingScreen from "../../../../components/misc/LoadingScreen";
@@ -22,13 +21,6 @@ const DefaultFlow = (props: { sessionId: string }) => {
 
   const nodes = nodeSelectors.selectAll(state.nodes);
   const edges = edgeSelectors.selectAll(state.edges);
-
-  const nodesInitialized = useNodesInitialized({ includeHiddenNodes: false });
-  useLayoutEffect(() => {
-    if (nodesInitialized) {
-      dispatch(layoutNodes(props.sessionId));
-    }
-  }, [nodesInitialized]);
 
   return (
     <SessionContext.Provider value={sessionEntity}>

--- a/packages/webview-ui/src/features/sessions/debugSessions/default/DefaultFlowComponent.tsx
+++ b/packages/webview-ui/src/features/sessions/debugSessions/default/DefaultFlowComponent.tsx
@@ -1,4 +1,5 @@
-import { useEffect } from "react";
+import "./DefaultFlowComponent.css";
+import { useLayoutEffect } from "react";
 import { Background, Controls, ReactFlow, useNodesInitialized } from "reactflow";
 import { useAppDispatch, useAppSelector } from "../../../../hooks";
 import { edgesAdapter, nodesAdapter } from "../../entities";
@@ -6,14 +7,15 @@ import { layoutNodes, nodesChanged } from "./defaultActions";
 import { nodeTypes } from "../../../../components/nodes";
 import { edgeTypes } from "../../../../components/edges";
 import LoadingScreen from "../../../../components/misc/LoadingScreen";
-
-import "./DefaultFlowComponent.css";
+import SessionContext from "../../SessionContext";
 
 const DefaultFlow = (props: { sessionId: string }) => {
   const dispatch = useAppDispatch();
   const state = useAppSelector((state) => state.sessions.sessionStates[props.sessionId]);
 
-  // const sessionEntity = useAppSelector((state) => state.sessions.sessionEntities.entities[props.sessionId]);
+  const sessionEntity = useAppSelector(
+    (state) => state.sessions.sessionEntities.entities[props.sessionId],
+  );
 
   const nodeSelectors = nodesAdapter.getSelectors();
   const edgeSelectors = edgesAdapter.getSelectors();
@@ -22,14 +24,14 @@ const DefaultFlow = (props: { sessionId: string }) => {
   const edges = edgeSelectors.selectAll(state.edges);
 
   const nodesInitialized = useNodesInitialized({ includeHiddenNodes: false });
-  useEffect(() => {
+  useLayoutEffect(() => {
     if (nodesInitialized) {
       dispatch(layoutNodes(props.sessionId));
     }
   }, [nodesInitialized]);
 
   return (
-    <>
+    <SessionContext.Provider value={sessionEntity}>
       <ReactFlow
         nodes={nodes}
         edges={edges}
@@ -41,7 +43,7 @@ const DefaultFlow = (props: { sessionId: string }) => {
         <Background />
         <Controls />
       </ReactFlow>
-    </>
+    </SessionContext.Provider>
   );
 };
 

--- a/packages/webview-ui/src/features/sessions/debugSessions/default/DefaultSession.ts
+++ b/packages/webview-ui/src/features/sessions/debugSessions/default/DefaultSession.ts
@@ -31,8 +31,8 @@ export default class DefaultSession extends BaseSession {
 
     // apply node changes from react flow
     builder.addCase(defaultActions.nodesChanged, defaultReducers.nodesChangedReducer);
-
     builder.addCase(defaultActions.layoutNodesDone, defaultReducers.layoutNodesDoneReducer);
+    builder.addCase(defaultActions.nodeMeasured, defaultReducers.nodeMeasuredReducer);
 
     builder.addCase(defaultActions.setLoading, defaultReducers.setLoadingReducer);
 

--- a/packages/webview-ui/src/features/sessions/debugSessions/default/DefaultSession.ts
+++ b/packages/webview-ui/src/features/sessions/debugSessions/default/DefaultSession.ts
@@ -44,24 +44,34 @@ export default class DefaultSession extends BaseSession {
   override component = getDefaultFlowComponent();
 
   override addListeners = (addListener: AppAddListener) => [
+    // sessionsInitialized
     addListener({
       predicate: (action) => sessionsInitialized.match(action) && this.fetchAfterInitialize,
       effect: (act, api) => this.debuggerStoppedEffect(act, api),
     }),
 
+    // "stopped" debug event
     addListener({
       matcher: matcherWithId(this.id, debugEventAction.stopped.match),
       effect: (act, api) => this.debuggerStoppedEffect(act, api),
     }),
 
+    // buildFLow
     addListener({
       matcher: matcherWithId(this.id, defaultActions.buildFlow.match),
       effect: (act, api) => this.buildFlowEffect(act, api),
     }),
 
+    // layoutNodes
     addListener({
       matcher: matcherWithId(this.id, defaultActions.layoutNodes.match),
       effect: (act, api) => this.layoutNodesEffect(act, api),
+    }),
+
+    // nodeMeasured
+    addListener({
+      matcher: matcherWithId(this.id, defaultActions.nodeMeasured.match),
+      effect: (act, api) => this.nodeMeasuredEffect(act, api),
     }),
   ];
 
@@ -75,6 +85,10 @@ export default class DefaultSession extends BaseSession {
   strategies = defaultStrategies;
 
   //#region listener effects
+  /**
+   * When the debugger stops, dispatch all actions needed to clear the debug objects,
+   * fetch new objects from the debug adapter, then build the nodes and edges for React Flow.
+   */
   debuggerStoppedEffect: AppListenerEffect = async (action, api) => {
     api.dispatch(defaultActions.updateLastPause(this.id));
     api.dispatch(defaultActions.removeAllDebugObjects(this.id));
@@ -86,8 +100,12 @@ export default class DefaultSession extends BaseSession {
     api.dispatch(defaultActions.setLoading(this.id, { loading: true }));
 
     try {
-      await this.strategies.fetchSession(this.id, this.strategies, api, stoppedThread);
+      await api.pause(this.strategies.fetchSession(this.id, this.strategies, api, stoppedThread));
     } catch (e) {
+      if (api.signal.aborted) {
+        // Don't show error message if listener was intentionally cancelled
+        return;
+      }
       console.error(e);
       MessageBox.showError(
         "An error occured while fetching the debug state. The flowchart shown may be missing or incomplete.",
@@ -98,17 +116,39 @@ export default class DefaultSession extends BaseSession {
     api.dispatch(defaultActions.setLoading(this.id, { loading: false }));
   };
 
+  /**
+   * Async handler for the `buildFlow` action.
+   *
+   * TODO: This is basically an async reducer, so it could probably be a thunk.
+   */
   buildFlowEffect: AppListenerEffect = async (_action, api) => {
     const state = api.getState().sessions.sessionStates[this.id];
-    const { nodes, edges } = await this.strategies.buildFlow(state);
+    const { nodes, edges } = await api.pause(this.strategies.buildFlow(state));
     api.dispatch(defaultActions.setAllFlowObjects(this.id, { nodes, edges }));
   };
 
+  /**
+   * Async handler for the `layoutFlow` action.
+   *
+   * TODO: This is basically an async reducer, so it could probably be a thunk.
+   */
   layoutNodesEffect: AppListenerEffect = async (_action, api) => {
     api.cancelActiveListeners();
     const state = api.getState().sessions.sessionStates[this.id];
-    const changes = await this.strategies.layoutFlow(state);
+    const changes = await api.pause(this.strategies.layoutFlow(state));
     api.dispatch(defaultActions.layoutNodesDone(this.id, { changes }));
+  };
+
+  /**
+   * Effect that dispatches `layoutNodes` after receiving the batched `nodeMeasured` actions.
+   */
+  nodeMeasuredEffect: AppListenerEffect = async (_action, api) => {
+    api.cancelActiveListeners();
+    // This effect is triggered several times at once.
+    // Debounce to make sure this listener code only runs once.
+    await api.delay(10);
+
+    api.dispatch(defaultActions.layoutNodes(this.id));
   };
   //#endregion listener effects
 }

--- a/packages/webview-ui/src/features/sessions/debugSessions/default/defaultActions.ts
+++ b/packages/webview-ui/src/features/sessions/debugSessions/default/defaultActions.ts
@@ -52,6 +52,10 @@ export const layoutNodesDone = createSessionAction<{ changes: NodeChange[] }>(
 );
 export const nodesChanged = createSessionAction<{ changes: NodeChange[] }>("session/nodesChanged");
 
+export const nodeMeasured = createSessionAction<{ id: string; size: { h: number; w: number } }>(
+  "session/nodeMeasured",
+);
+
 export const updateLastPause = createAction("session/updateLastPause", (sessionId: string) => ({
   payload: { lastPause: Date.now() },
   meta: { sessionId },

--- a/packages/webview-ui/src/features/sessions/debugSessions/default/defaultActions.ts
+++ b/packages/webview-ui/src/features/sessions/debugSessions/default/defaultActions.ts
@@ -8,7 +8,7 @@ import {
   EdgeEntity,
 } from "../../entities";
 import { createSessionAction } from "../../sessionAction";
-import { createAction } from "@reduxjs/toolkit";
+import { SHOULD_AUTOBATCH, createAction } from "@reduxjs/toolkit";
 
 type SetAllDebugObjectsPayload = {
   threads: ThreadEntity[];
@@ -52,8 +52,13 @@ export const layoutNodesDone = createSessionAction<{ changes: NodeChange[] }>(
 );
 export const nodesChanged = createSessionAction<{ changes: NodeChange[] }>("session/nodesChanged");
 
-export const nodeMeasured = createSessionAction<{ id: string; size: { h: number; w: number } }>(
+type NodeMeasuredPayload = { id: string; size: { h: number; w: number } };
+export const nodeMeasured = createAction(
   "session/nodeMeasured",
+  (sessionId: string, payload: NodeMeasuredPayload) => ({
+    payload,
+    meta: { sessionId, [SHOULD_AUTOBATCH]: true },
+  }),
 );
 
 export const updateLastPause = createAction("session/updateLastPause", (sessionId: string) => ({

--- a/packages/webview-ui/src/features/sessions/debugSessions/default/defaultReducers.ts
+++ b/packages/webview-ui/src/features/sessions/debugSessions/default/defaultReducers.ts
@@ -102,6 +102,22 @@ export const layoutNodesDoneReducer: CR<typeof defaultActions.layoutNodesDone> =
   );
 };
 
+export const nodeMeasuredReducer: CR<typeof defaultActions.nodeMeasured> = (state, action) => {
+  const node = nodeSelectors.selectById(state.nodes, action.payload.id);
+  if (node === undefined) {
+    return;
+  }
+  nodesAdapter.updateOne(state.nodes, {
+    id: action.payload.id,
+    changes: {
+      data: {
+        ...node.data,
+        measuredSize: action.payload.size,
+      },
+    },
+  });
+};
+
 export const updateLastStopReducer: CR<typeof defaultActions.updateLastPause> = (state, action) => {
   state.lastPause = action.payload.lastPause;
 };

--- a/packages/webview-ui/src/features/sessions/debugSessions/default/strategies/defaultBuildFlowStrategy.ts
+++ b/packages/webview-ui/src/features/sessions/debugSessions/default/strategies/defaultBuildFlowStrategy.ts
@@ -33,7 +33,7 @@ async function defaultBuildFlowStrategy(
     type: "commonStackTrace",
     id: "stack-trace",
     position: { x: 0, y: 0 },
-    data: {},
+    data: { measuredSize: null },
   };
   nodes.push(stackTraceNode);
 
@@ -48,6 +48,7 @@ async function defaultBuildFlowStrategy(
         name: frame.name,
         scopes: [],
         stackPosition: i,
+        measuredSize: null,
       },
       parentNode: "stack-trace",
       draggable: false,
@@ -184,6 +185,7 @@ async function defaultBuildFlowStrategy(
       data: {
         name: variable.type,
         items: variablesListItems,
+        measuredSize: null,
       },
       id: variable.entity.pedagogId,
       position: { x: 0, y: 0 },

--- a/packages/webview-ui/src/features/sessions/debugSessions/default/strategies/defaultLayoutFlowStrategy.ts
+++ b/packages/webview-ui/src/features/sessions/debugSessions/default/strategies/defaultLayoutFlowStrategy.ts
@@ -67,8 +67,8 @@ export default async function defaultLayoutNodesStrategy(
       const stackPosition = (node.data as StackFrameData).stackPosition;
       elkStackTraceNode.children!.push({
         id: node.id,
-        width: node.width!,
-        height: node.height!,
+        width: node.data.measuredSize?.w ?? node.width ?? undefined,
+        height: node.data.measuredSize?.h ?? node.height ?? undefined,
         labels: [{ text: node.data.name }],
         layoutOptions: {
           position: `(0,${stackPosition})`,
@@ -80,17 +80,16 @@ export default async function defaultLayoutNodesStrategy(
         id: node.id,
         // x: node.data.isLayouted ? node.position.x : undefined,
         // y: node.data.isLayouted ? node.position.y : undefined,
-        width: node.width!,
-        height: node.height!,
+        width: node.data.measuredSize?.w ?? node.width ?? undefined,
+        height: node.data.measuredSize?.h ?? node.height ?? undefined,
         labels: node.data.name ? [{ text: node.data.name }] : undefined,
         ...(node.data.isLayouted ? { x: node.position.x, y: node.position.y } : undefined),
       });
     }
   }
 
-  isDevEnvironment && console.debug("Pre-layout graph:", JSON.stringify(elkRootNode));
   const layoutedGraph = await elk.layout(elkRootNode);
-  isDevEnvironment && console.debug("Post-layout graph:", JSON.stringify(layoutedGraph));
+  isDevEnvironment && console.debug("Layouted graph:", JSON.stringify(layoutedGraph));
 
   const layoutedNodes: ElkNode[] = layoutedGraph.children!.flatMap((elkNode) => [
     {
@@ -99,7 +98,6 @@ export default async function defaultLayoutNodesStrategy(
     },
     ...(elkNode.children ?? []),
   ]);
-  console.log("layouted graph:", layoutedGraph);
 
   const positionChanges: NodeChange[] = layoutedNodes.map((elkNode) => ({
     id: elkNode.id,


### PR DESCRIPTION
- Added `measuredSize` property to `BaseNodeData`
- Added [autobatched](https://redux-toolkit.js.org/api/autoBatchEnhancer) `nodeMeasured` action to update `measuredSize`
- Added `useMeasureNode` hook that dispatches the correct measured node size after rendering
- Added listener that dispatches `layoutNodes` after receiving the batched `nodeMeasured` actions

Fixes #15 